### PR TITLE
feat: add additional read-only policy for all argo projects

### DIFF
--- a/argocd/product-behaviour-twin-pilot/read-write/resources/argo-project.yaml
+++ b/argocd/product-behaviour-twin-pilot/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-behaviour-twin-pilot:team-admin, exec, create, product-behaviour-twin-pilot/*, allow
       groups:
         - catenax-ng:product-behaviour-twin-pilot
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-behaviour-twin-pilot:read-only, applications, get, project-behaviour-twin-pilot/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-bpdm/read-write/resources/argo-project.yaml
+++ b/argocd/product-bpdm/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-bpdm:team-admin, exec, create, product-bpdm/*, allow
       groups:
         - catenax-ng:product-bpdm
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-bpdm:read-only, applications, get, project-bpdm/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-business-partner-certificates/read-write/resources/argo-project.yaml
+++ b/argocd/product-business-partner-certificates/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-business-partner-certificates:team-admin, exec, create, product-business-partner-certificates/*, allow
       groups:
         - catenax-ng:product-business-partner-certificates
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-business-partner-certificates:read-only, applications, get, project-business-partner-certificates/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-catenax-at-home/read-write/resources/argo-project.yaml
+++ b/argocd/product-catenax-at-home/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-catenax-at-home:team-admin, exec, create, product-catenax-at-home/*, allow
       groups:
         - catenax-ng:product-catenax-at-home
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-catenax-at-home:read-only, applications, get, project-catenax-at-home/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-data-format-transformer/read-write/resources/argo-project.yaml
+++ b/argocd/product-data-format-transformer/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-product-data-format-transformer:team-admin, exec, create, product-product-data-format-transformer/*, allow
       groups:
         - catenax-ng:product-product-data-format-transformer
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-product-data-format-transformer:read-only, applications, get, project-product-data-format-transformer/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-data-integrity-demonstrator/read-write/resources/argo-project.yaml
+++ b/argocd/product-data-integrity-demonstrator/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-data-integrity-demonstrator:team-admin, exec, create, product-data-integrity-demonstrator/*, allow
       groups:
         - catenax-ng:product-data-integrity-demonstrator
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-data-integrity-demonstrator:read-only, applications, get, project-data-integrity-demonstrator/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-dft/read-write/resources/argo-project.yaml
+++ b/argocd/product-dft/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-dft:team-admin, exec, create, product-dft/*, allow
       groups:
         - catenax-ng:product-dft
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-dft:read-only, applications, get, project-dft/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-edc/read-write/resources/argo-project.yaml
+++ b/argocd/product-edc/read-write/resources/argo-project.yaml
@@ -25,3 +25,10 @@ spec:
         - p, proj:product-edc:team-admin, exec, create, product-edc/*, allow
       groups:
         - catenax-ng:product-edc
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-edc:read-only, applications, get, project-edc/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-esc-backbone/read-write/resources/argo-project.yaml
+++ b/argocd/product-esc-backbone/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-esc-backbone:team-admin, exec, create, product-esc-backbone/*, allow
       groups:
         - catenax-ng:product-esc-backbone
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-esc-backbone:read-only, applications, get, project-esc-backbone/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-essential-services/read-write/resources/argo-project.yaml
+++ b/argocd/product-essential-services/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-essential-services:team-admin, exec, create, product-essential-services/*, allow
       groups:
         - catenax-ng:product-essential-services
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-essential-services:read-only, applications, get, project-essential-services/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-et-demonstrators/read-write/resources/argo-project.yaml
+++ b/argocd/product-et-demonstrators/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-et-demonstrators:team-admin, exec, create, product-et-demonstrators/*, allow
       groups:
         - catenax-ng:product-et-demonstrators
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-et-demonstrators:read-only, applications, get, project-et-demonstrators/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-example/read-write/resources/argo-project.yaml
+++ b/argocd/product-example/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-team-example:team-admin, exec, create, product-team-example/*, allow
       groups:
         - catenax-ng:product-team-example
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-example:read-only, applications, get, project-example/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-explorer/read-write/resources/argo-project.yaml
+++ b/argocd/product-explorer/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-explorer:team-admin, exec, create, product-explorer/*, allow
       groups:
         - catenax-ng:product-explorer
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-explorer:read-only, applications, get, project-explorer/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-innovation-radar/read-write/resources/argo-project.yaml
+++ b/argocd/product-innovation-radar/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-innovation-radar:team-admin, exec, create, product-innovation-radar/*, allow
       groups:
         - catenax-ng:product-innovation-radar
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-innovation-radar:read-only, applications, get, project-innovation-radar/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-item-relationship-service-frontend/read-write/resources/argo-project.yaml
+++ b/argocd/product-item-relationship-service-frontend/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-item-relationship-service-frontend:team-admin, exec, create, product-item-relationship-service-frontend/*, allow
       groups:
         - catenax-ng:product-item-relationship-service-frontend
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-item-relationship-service-frontend:read-only, applications, get, project-item-relationship-service-frontend/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-knowledge/read-write/resources/argo-project.yaml
+++ b/argocd/product-knowledge/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-knowledge:team-admin, exec, create, product-knowledge/*, allow
       groups:
         - catenax-ng:product-knowledge
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-knowledge:read-only, applications, get, project-knowledge/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-managed-identity-wallets/read-write/resources/argo-project.yaml
+++ b/argocd/product-managed-identity-wallets/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-managed-identity-wallets:team-admin, exec, create, product-managed-identity-wallets/*, allow
       groups:
         - catenax-ng:product-managed-identity-wallets
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-managed-identity-wallets:read-only, applications, get, project-managed-identity-wallets/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-material-pass/read-write/resources/argo-project.yaml
+++ b/argocd/product-material-pass/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-material-pass:team-admin, exec, create, product-material-pass/*, allow
       groups:
         - catenax-ng:product-material-pass
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-material-pass:read-only, applications, get, project-material-pass/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-portal/read-write/resources/argo-project.yaml
+++ b/argocd/product-portal/read-write/resources/argo-project.yaml
@@ -21,3 +21,10 @@ spec:
         - p, proj:product-portal:team-admin, exec, create, product-portal/*, allow
       groups:
         - catenax-ng:product-portal
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-portal:read-only, applications, get, project-portal/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-r-strategy-assistant/read-write/resources/argo-project.yaml
+++ b/argocd/product-r-strategy-assistant/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-r-strategy-assistant:team-admin, exec, create, product-r-strategy-assistant/*, allow
       groups:
         - catenax-ng:product-r-strategy-assistant
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-r-strategy-assistant:read-only, applications, get, project-r-strategy-assistant/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-semantics/read-write/resources/argo-project.yaml
+++ b/argocd/product-semantics/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-semantics:team-admin, exec, create, product-semantics/*, allow
       groups:
         - catenax-ng:product-semantics
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-semantics:read-only, applications, get, project-semantics/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-test-data-generator/read-write/resources/argo-project.yaml
+++ b/argocd/product-test-data-generator/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-test-data-generator:team-admin, exec, create, product-test-data-generator/*, allow
       groups:
         - catenax-ng:product-test-data-generator
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-test-data-generator:read-only, applications, get, project-test-data-generator/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-traceability-foss:team-admin, exec, create, product-traceability-foss/*, allow
       groups:
         - catenax-ng:product-traceability-foss
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-traceability-foss:read-only, applications, get, project-traceability-foss/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-traceability-irs/read-write/resources/argo-project.yaml
+++ b/argocd/product-traceability-irs/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-traceability-irs:team-admin, exec, create, product-traceability-irs/*, allow
       groups:
         - catenax-ng:product-traceability-irs
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-traceability-irs:read-only, applications, get, project-traceability-irs/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-value-added-service/read-write/resources/argo-project.yaml
+++ b/argocd/product-value-added-service/read-write/resources/argo-project.yaml
@@ -17,3 +17,10 @@ spec:
         - p, proj:product-value-added-service:team-admin, exec, create, product-value-added-service/*, allow
       groups:
         - catenax-ng:product-value-added-service
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-value-added-service:read-only, applications, get, project-value-added-service/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management


### PR DESCRIPTION
This PR enables the realease-management and test-management teams of our GitHub org to view apps on Argo CD.
