### PR TITLE
chore: AVP secret setup for cluster-stack (except core)

### DIFF
--- a/argocd/argocdadmins/read-write/kustomization.yaml
+++ b/argocd/argocdadmins/read-write/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # Namespaces to create
+  - resources/namespaces.yaml
+
+  # AVP secrets to create in namespaces
+#  - resources/avp-secrets/avp-secret-app-dashboard.yaml # currently AVP unused here
+  - resources/avp-secrets/avp-secret-argocd.yaml
+  - resources/avp-secrets/avp-secret-cert-manager.yaml
+#  - resources/avp-secrets/avp-secret-default.yaml # currently no ApplicationSet used AVP here
+  - resources/avp-secrets/avp-secret-monitoring.yaml
+  - resources/avp-secrets/avp-secret-kyverno.yaml
+  - resources/avp-secrets/avp-secret-logging.yaml
+  - resources/avp-secrets/avp-secret-maintenance-dashboard-app.yaml
+  - resources/avp-secrets/avp-secret-reflector.yaml
+  - resources/avp-secrets/avp-secret-tls.yaml

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-app-dashboard.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-app-dashboard.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: app-dashboard
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-argocd.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-argocd.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: argocd
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-cert-manager.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-cert-manager.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: cert-manager
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-default.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-default.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: default
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-kyverno.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-kyverno.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: kyverno
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-logging.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-logging.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: logging
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-maintenance-dashboard-app.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-maintenance-dashboard-app.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: maintenance-dashboard-app
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-monitoring.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: monitoring
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-reflector.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-reflector.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: reflector
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-tls.yaml
+++ b/argocd/argocdadmins/read-write/resources/avp-secrets/avp-secret-tls.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
+  name: vault-secret
+  namespace: tls
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/argocdadmins/read-write/resources/namespaces.yaml
+++ b/argocd/argocdadmins/read-write/resources/namespaces.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-dashboard
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maintenance-dashboard-app
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reflector
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tls

--- a/cluster/beta/kustomization.yaml
+++ b/cluster/beta/kustomization.yaml
@@ -2,7 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCDAdmins
+  - ../../argocd/argocdadmins/read-write
 
+  # Product Onboarding
   - ../../argocd/product-bpdm/read-write
   - ../../argocd/product-data-format-transformer/read-write
   - ../../argocd/product-essential-services/read-write

--- a/cluster/dev/kustomization.yaml
+++ b/cluster/dev/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCDAdmins
+  - ../../argocd/argocdadmins/read-write
+
+  # Product Onboarding
   - ../../argocd/product-behaviour-twin-pilot/read-write
   - ../../argocd/product-bpdm/read-write
   - ../../argocd/product-business-partner-certificates/read-write

--- a/cluster/devsecops-testing/kustomization.yaml
+++ b/cluster/devsecops-testing/kustomization.yaml
@@ -2,5 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCDAdmins
+  - ../../argocd/argocdadmins/read-write
 
+  # Product Onboarding
   - ../../argocd/product-example/read-write

--- a/cluster/int/kustomization.yaml
+++ b/cluster/int/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCDAdmins
+  - ../../argocd/argocdadmins/read-write
+
+  # Product Onboarding
   - ../../argocd/product-behaviour-twin-pilot/read-write
   - ../../argocd/product-bpdm/read-write
   - ../../argocd/product-business-partner-certificates/read-write

--- a/cluster/pre-prod/kustomization.yaml
+++ b/cluster/pre-prod/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCDAdmins
+  - ../../argocd/argocdadmins/read-write
+
+  # Product Onboarding
   - ../../argocd/product-behaviour-twin-pilot/base-read-only
   - ../../argocd/product-bpdm/base-read-only
   - ../../argocd/product-business-partner-certificates/base-read-only


### PR DESCRIPTION
Adopt new AVP setup to k8s-cluster-stack related namespaces.

This is something like a rfc. If you have improvements or suggestions, feel free :) Also we have to think of how to setup AVP secrets on core cluster (as core is not part of this repository).