### PR TITLE
A1ODT-1234 Trace-X product Repositories to readonly

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -2016,7 +2016,7 @@ github_repositories_teams = {
   "product-traceability-foss-backend-product-traceability-foss" : {
     team_name : "product-traceability-foss"
     repository : "product-traceability-foss-backend"
-    permission : "maintain"
+    permission : "pull"
   },
   "product-esc-backbone-code-product-esc-backbone" : {
     team_name : "product-esc-backbone"

--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -663,7 +663,7 @@ github_repositories = {
   "product-traceability-foss-frontend" : {
     name : "product-traceability-foss-frontend"
     team_name : "product-traceability-foss"
-    description : "DEPRECATED - use https://github.com/catenax-ng/tx-traceability-foss-frontend"
+    description : "DEPRECATED - use https://github.com/eclipse-tractusx/traceability-foss-frontend"
     visibility : "public"
     homepage_url : ""
     topics : []
@@ -680,7 +680,7 @@ github_repositories = {
   "product-traceability-foss-backend" : {
     name : "product-traceability-foss-backend"
     team_name : "product-traceability-foss"
-    description : "DEPRECATED - use https://github.com/catenax-ng/tx-traceability-foss-backend"
+    description : "DEPRECATED - use https://github.com/eclipse-tractusx/traceability-foss-backend"
     visibility : "public"
     homepage_url : ""
     topics : []

--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -2011,7 +2011,7 @@ github_repositories_teams = {
   "product-traceability-foss-frontend-product-traceability-foss" : {
     team_name : "product-traceability-foss"
     repository : "product-traceability-foss-frontend"
-    permission : "maintain"
+    permission : "pull"
   },
   "product-traceability-foss-backend-product-traceability-foss" : {
     team_name : "product-traceability-foss"


### PR DESCRIPTION
changed the github teams permission for trace-x team to read-only

for following repositories

- https://github.com/catenax-ng/product-traceability-foss-backend
- https://github.com/catenax-ng/product-traceability-foss-frontend

terraform plan looks like:
permission = "maintain" -> "pull"

Plan: 0 to add, 2 to change, 0 to destroy.
