### PR TITLE
add support and security issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-support--request.md
+++ b/.github/ISSUE_TEMPLATE/security-support--request.md
@@ -1,0 +1,17 @@
+---
+name: 'Security Support: Request'
+about: If you have a Security Request
+title: Security Request
+labels: security
+assignees: ''
+
+---
+
+**Please specify the type of request. Exemplary requests are:**
+
+Veracode (initial setup, github integration)
+Trivvy
+KICS
+Gitguardian
+Pentesting
+Security risk assessment (RRA, Threat modeling, Code reviews)

--- a/.github/ISSUE_TEMPLATE/security-support--sonarcloud-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/security-support--sonarcloud-onboarding.md
@@ -1,0 +1,12 @@
+---
+name: 'Security Support: SonarCloud onboarding'
+about: If you need a SonarCloud onboarding
+title: SonarCloud Onboarding
+labels: security
+assignees: ''
+
+---
+
+**Please provide your public repository**
+
+repository: *your_repository*

--- a/.github/ISSUE_TEMPLATE/support--create-a-new-environment.md
+++ b/.github/ISSUE_TEMPLATE/support--create-a-new-environment.md
@@ -1,0 +1,19 @@
+---
+name: 'Support: Create a New Environment'
+about: If you need a hole new Environment for a good reason
+title: New Environment
+labels: support
+assignees: FaGru3n
+
+---
+
+Purpose: environment_purpose
+Requested by: person_requesting_the_demonstration_environment
+End date of demonstration: dd.mm.yyyy
+Teams participating:
+
+product_team_name
+
+> BEWARE: 
+> We do not provide dedicated environments for single teams. We will provide a DEV, INT, and 
+PRE-PROD environment and teams will collectively use these environments together. A list of available environments can be found in the X Conf.

--- a/.github/ISSUE_TEMPLATE/support--create-a-new-fork.md
+++ b/.github/ISSUE_TEMPLATE/support--create-a-new-fork.md
@@ -1,0 +1,19 @@
+---
+name: 'Support: Create a new Fork'
+about: If you need a new fork from T into X Orga
+title: 'GitHub: New T fork'
+labels: support
+assignees: ''
+
+---
+
+Please fill in need information between <your-information>
+
+repository name within T Organisation: 
+*repo_name*
+
+repository name within C Organisation: 
+tx-*repo_name*
+
+GitHub team to grant access: 
+*github_team_name*

--- a/.github/ISSUE_TEMPLATE/support--create-a-new-github-repository.md
+++ b/.github/ISSUE_TEMPLATE/support--create-a-new-github-repository.md
@@ -1,0 +1,12 @@
+---
+name: 'Support: Create a new GitHub repository'
+about: If you need a new repository within X Orga
+title: 'GitHub: New repository '
+labels: support
+assignees: ''
+
+---
+
+Required information:
+- Details to your GitHub repository: product-Your_Product_Name
+- Details to GitHub team to grant access: github_team_name

--- a/.github/ISSUE_TEMPLATE/support--create-a-new-github-team.md
+++ b/.github/ISSUE_TEMPLATE/support--create-a-new-github-team.md
@@ -1,0 +1,15 @@
+---
+name: 'Support: Create a new GitHub Team'
+about: If you need a new team within X Orga
+title: 'GitHub: New Team'
+labels: support
+assignees: ''
+
+---
+
+Product GitHub team name: <your_product_team_name>
+GitHub users to invite:
+- github_user_account
+
+Maintainer of the new GitHub Team:
+- github_user_account

--- a/.github/ISSUE_TEMPLATE/support--general-requirement.md
+++ b/.github/ISSUE_TEMPLATE/support--general-requirement.md
@@ -1,0 +1,19 @@
+---
+name: 'Support: General Requirement'
+about: If you have a general question
+title: ''
+labels: support
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+Additional context
+Add any other context or screenshots about the feature request here.
+
+GitHub user: *your_user*

--- a/.github/ISSUE_TEMPLATE/support--invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support--invite-member-to-github-org.md
@@ -1,0 +1,14 @@
+---
+name: 'Support: Invite member to GitHub Org'
+about: If you need to invite a new Member within X Orga
+title: 'GitHub: Invite member '
+labels: support
+assignees: ''
+
+---
+
+new GitHub user: GITHUB-USER-ID
+
+who can verfiy that the new user is a Member of X Org
+
+Vouching person: your_PO

--- a/.github/ISSUE_TEMPLATE/support--onboard-a-new-product.md
+++ b/.github/ISSUE_TEMPLATE/support--onboard-a-new-product.md
@@ -1,0 +1,14 @@
+---
+name: 'Support: Onboard a new product'
+about: If you need a complete new product within X Orga
+title: New Product
+labels: support
+assignees: ''
+
+---
+
+Product name: product-<Your-Product-Name>
+GitHub users to invite: github_user_accounts
+Vouching person: your_PO
+
+(including new GitHub-team, new GitHub-repository, ArgoCD and Vault)

--- a/.github/ISSUE_TEMPLATE/support--request-access-to-an-existing-environment-namespace.md
+++ b/.github/ISSUE_TEMPLATE/support--request-access-to-an-existing-environment-namespace.md
@@ -1,0 +1,13 @@
+---
+name: 'Support: Request access to an existing environment/namespace'
+about: If you need access to existing products
+title: 'Environment: request access'
+labels: support
+assignees: ''
+
+---
+
+Environment: DEV / INT
+namespace: name_of_namespace
+GitHub team: team_that_should_have_access
+GitHub users: github_user_that_should_have_access


### PR DESCRIPTION
- add some default templates
- naming or input draft things and could be apapted afterwards to our needs
- blank issue still available