### PR TITLE
chore: add new team cgi-dcm-foss

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -195,6 +195,10 @@ github_teams = {
   "bpdm-documentation" : {
     name : "bpdm-documentation"
     description : "Content team for product-bpdm-documentation"
+  },
+  "cgi-dcm-foss" : {
+    name : "cgi-dcm-foss"
+    description : "Content team for tx-dcm-backend"
   }
 }
 
@@ -1780,11 +1784,11 @@ github_repositories = {
   "product-agents-edc" : {
     name : "product-agents-edc"
     team_name : "product-knowledge"
-    description : ""
+    description : "EDC Agent Plane"
     visibility : "public"
     has_issues : false
-    homepage_url : ""
-    topics : []
+    homepage_url : "https://catenax-ng.github.io/product-knowledge/"
+    topics : ["catena-x","eclipse-dataspace-components","semantic-web","sparql"]
     pages : {
       enabled : true
       branch : "gh-pages"
@@ -1799,11 +1803,11 @@ github_repositories = {
   "product-agents" : {
     name : "product-agents"
     team_name : "product-knowledge"
-    description : ""
+    description : "Reference Implementations of Knowledge Agents"
     visibility : "public"
     has_issues : false
-    homepage_url : ""
-    topics : []
+    homepage_url : "https://catenax-ng.github.io/product-knowledge/"
+    topics : ["catena-x","semantic-web","sparql"]
     pages : {
       enabled : true
       branch : "gh-pages"

--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -196,8 +196,8 @@ github_teams = {
     name : "bpdm-documentation"
     description : "Content team for product-bpdm-documentation"
   },
-  "cgi-dcm-foss" : {
-    name : "cgi-dcm-foss"
+  "product-cgi-dcm-foss" : {
+    name : "product-cgi-dcm-foss"
     description : "Content team for tx-dcm-backend"
   }
 }


### PR DESCRIPTION
### Description
#### What you changed / added?
- added new gh-team as requested in https://github.com/eclipse-tractusx/sig-infra/issues/26
- adapt repository changes from other repositories in our terraform state
#### Why?
- team management for new team within catenax-ng
#### Testing
- terraform plan within github folder structure and your token
#### Additional information
Plan: 1 to add, 0 to change, 0 to destroy.
