### PR TITLE
chore: add new repo .github

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -1837,6 +1837,25 @@ github_repositories = {
     codeowners_available : false
     codeowners : null
     archived : false
+  },
+  ".github" : {
+    name : ".github"
+    team_name : "argocdadmins"
+    description : "Catena-X NG organisation repository"
+    visibility : "public"
+    has_issues : false
+    homepage_url : ""
+    topics : []
+    pages : {
+      enabled : false
+      branch : "gh-pages"
+    }
+    is_template : false
+    uses_template : false
+    template : null
+    codeowners_available : false
+    codeowners : null
+    archived : false
   }
 }
 
@@ -2301,5 +2320,10 @@ github_repositories_teams = {
     team_name : "bpdm-documentation"
     repository : "product-bpdm-documentation"
     permission : "maintain"
+  },
+  ".github-argocdadmins" : {
+    team_name : "argocdadmins"
+    repository : ".github"
+    permission : "admin"
   }
 }


### PR DESCRIPTION
### Description
#### What you changed / added?
- add public organisation repository named `.github`
#### Why?
- to use the `profile/README.md` we need to add a special GitHub repository named `.github` 
- because we manage this repositories over Terraform this the PR 
#### Testing
- checkout branch `chore/create-organisation-repo`
- `terraform plan`
- verify changes under additional information
#### Additional information
Plan: 2 to add, 0 to change, 0 to destroy.
1 to add for repository `.github`
1 to add repo-team permission `.github-argocdadmins`
