### PR TITLE
chore: make repo product-bpdm-documentation private

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -1827,7 +1827,7 @@ github_repositories = {
     name : "product-bpdm-documentation"
     team_name : "bpdm-documentation"
     description : ""
-    visibility : "public"
+    visibility : "private"
     has_issues : false
     homepage_url : ""
     topics : []
@@ -2288,11 +2288,6 @@ github_repositories_teams = {
   "eclipse-tractusx.github.io-traceability-spec" : {
     team_name : "traceability-spec"
     repository : "eclipse-tractusx.github.io"
-    permission : "maintain"
-  }
-  "product-vcissuer-product-edc" : {
-    team_name : "product-edc"
-    repository : "product-lab-ssi"
     permission : "maintain"
   }
   "product-portal-tools-product-portal" : {


### PR DESCRIPTION
#### What would be changed or will be added with this PR?
- make repo private
- remove outdated repo team permission block
#### Why do i want to change this?
- support issue https://github.com/eclipse-tractusx/sig-infra/issues/63
#### Additional information
Terraform will perform the following actions:
Plan: 1 to add, 1 to change, 0 to destroy.

[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>