### PR TITLE
chore: add secret-engine for quality-foss-app

### DIFF
--- a/vault/.terraform.lock.hcl
+++ b/vault/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/vault" {
   version     = "3.17.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:7xTn3wS4mMa3HpqqnhtBEs9EModIY9mkDrCVSUP2ADM=",
     "h1:v/3HHQpH6Qz5UZ82stshfLbcL3fwSy0OAnL54zQqa5A=",
     "zh:06eca14b5c002aa9f93ac2fe05da3e3d320d7804a896021a7a8ba3f78df2b1b7",
     "zh:104594e517adad642e73a32e11d3cbf64264d645d5ebbb4a30e503bd53d133c5",

--- a/vault/terraform.tfvars
+++ b/vault/terraform.tfvars
@@ -8,7 +8,7 @@
 #   approle_name : "<new-vault-app-role-name>"
 #   approle_policy_name : "<new-vault-product-technical-permissions-for-vault-default-ro>"
 #   github_team : "<new-product-team-gh-team-name>"
-#   avp_secret_name : "<new-argocd-vault-plugin-sercret-for-new-product-team>"
+#   avp_secret_name : "<new-argocd-vault-plugin-secret-for-new-product-team>"
 # },
 
 product_teams = {
@@ -255,5 +255,14 @@ product_teams = {
     approle_policy_name : "cgi-dcm-foss-ro"
     github_team : "product-cgi-dcm-foss"
     avp_secret_name : "cgi-dcm-foss"
+  },
+  "quality-foss-app" : {
+    name : "quality-foss-app",
+    secret_engine_name : "quality-foss-app"
+    ui_policy_name : "quality-foss-app-rw"
+    approle_name : "quality-foss-app"
+    approle_policy_name : "quality-foss-app-ro"
+    github_team : "product-quality-foss-app-team"
+    avp_secret_name : "quality-foss-app"
   }
 }


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- add secret engine for quality-foss-app
#### Why do i want to change this?
-  eclipse-tractusx/sig-infra#76
-  eclipse-tractusx/sig-infra#75
#### Additional information
``` bash
Terraform will perform the following actions:

  # vault_approle_auth_backend_role.product-team-approles["quality-foss-app"] will be created
  + resource "vault_approle_auth_backend_role" "product-team-approles" {
      + backend            = "approle"
      + bind_secret_id     = true
      + id                 = (known after apply)
      + role_id            = (known after apply)
      + role_name          = "quality-foss-app"
      + secret_id_num_uses = 0
      + secret_id_ttl      = 0
      + token_max_ttl      = 1800
      + token_num_uses     = 0
      + token_policies     = [
          + "quality-foss-app-ro",
        ]
      + token_ttl          = 1200
      + token_type         = "default"
    }

  # vault_approle_auth_backend_role_secret_id.product-teams-approle-ids["quality-foss-app"] will be created
  + resource "vault_approle_auth_backend_role_secret_id" "product-teams-approle-ids" {
      + accessor          = (known after apply)
      + backend           = "approle"
      + id                = (known after apply)
      + role_name         = "quality-foss-app"
      + secret_id         = (sensitive value)
      + wrapping_accessor = (known after apply)
      + wrapping_token    = (sensitive value)
    }

  # vault_generic_secret.product-team-avp-secrets["quality-foss-app"] will be created
  + resource "vault_generic_secret" "product-team-avp-secrets" {
      + data                = (sensitive value)
      + data_json           = (sensitive value)
      + delete_all_versions = false
      + disable_read        = false
      + id                  = (known after apply)
      + path                = "devsecops/avp-config/quality-foss-app"
    }

  # vault_github_team.github-product-teams["quality-foss-app"] will be created
  + resource "vault_github_team" "github-product-teams" {
      + backend  = "github"
      + id       = (known after apply)
      + policies = [
          + "quality-foss-app-rw",
        ]
      + team     = "product-quality-foss-app-team"
    }

  # vault_jwt_auth_backend_role.oidc_auth_roles["quality-foss-app"] will be created
  + resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
      + allowed_redirect_uris        = [
          + "http://localhost:8250/oidc/callback",
          + "https://vault.demo.catena-x.net/ui/vault/auth/oidc/oidc/callback",
        ]
      + backend                      = "oidc"
      + bound_claims                 = {
          + "groups" = "catenax-ng:product-quality-foss-app-team"
        }
      + bound_claims_type            = (known after apply)
      + clock_skew_leeway            = 0
      + disable_bound_claims_parsing = false
      + expiration_leeway            = 0
      + id                           = (known after apply)
      + not_before_leeway            = 0
      + oidc_scopes                  = [
          + "email",
          + "groups",
          + "openid",
        ]
      + role_name                    = "product-quality-foss-app-team"
      + role_type                    = "oidc"
      + token_policies               = [
          + "quality-foss-app-rw",
        ]
      + token_type                   = "default"
      + user_claim                   = "email"
      + user_claim_json_pointer      = false
      + verbose_oidc_logging         = false
    }

  # vault_mount.product-team-secret-engines["quality-foss-app"] will be created
  + resource "vault_mount" "product-team-secret-engines" {
      + accessor                     = (known after apply)
      + audit_non_hmac_request_keys  = (known after apply)
      + audit_non_hmac_response_keys = (known after apply)
      + default_lease_ttl_seconds    = (known after apply)
      + description                  = "Secret engine for team quality-foss-app"
      + external_entropy_access      = false
      + id                           = (known after apply)
      + max_lease_ttl_seconds        = (known after apply)
      + options                      = {
          + "version" = "2"
        }
      + path                         = "quality-foss-app"
      + seal_wrap                    = (known after apply)
      + type                         = "kv"
    }

  # vault_policy.product-approle-read-only-policies["quality-foss-app"] will be created
  + resource "vault_policy" "product-approle-read-only-policies" {
      + id     = (known after apply)
      + name   = "quality-foss-app-ro"
      + policy = <<-EOT
            path "quality-foss-app/*" {
              capabilities = [ "read" ]
            }
        EOT
    }

  # vault_policy.product-team-policies["quality-foss-app"] will be created
  + resource "vault_policy" "product-team-policies" {
      + id     = (known after apply)
      + name   = "quality-foss-app-rw"
      + policy = <<-EOT
            path "quality-foss-app/*" {
              capabilities = [ "create", "read", "update", "delete", "list" ]
            }
        EOT
    }

Plan: 8 to add, 0 to change, 0 to destroy.
```
[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>
