### PR TITLE
chore: create private repo product-federated-catalogue

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -1905,6 +1905,26 @@ github_repositories = {
     codeowners_available : false
     codeowners : null
     archived : false
+  },
+  "product-federated-catalogue" : {
+    name : "product-federated-catalogue"
+    team_name : "product-essential-services"
+    description : ""
+    visibility : "private"
+    has_issues : false
+    has_discussions : false
+    homepage_url : ""
+    topics : []
+    pages : {
+      enabled : false
+      branch : "gh-pages"
+    }
+    is_template : false
+    uses_template : false
+    template : null
+    codeowners_available : false
+    codeowners : null
+    archived : false
   }
 }
 
@@ -2358,6 +2378,11 @@ github_repositories_teams = {
   "product-quality-foss-app-product-quality-foss-app-team" : {
     team_name : "product-quality-foss-app-team"
     repository : "product-quality-foss-app"
+    permission : "maintain"
+  },
+  "product-federated-catalogue-product-essential-services" : {
+    team_name : "product-essential-services"
+    repository : "product-federated-catalogue"
     permission : "maintain"
   }
 }


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- add a new private repo `product-federated-catalogue`
- add new gh-team permission to this repo for gh-team `product-essential-services` 

updates eclipse-tractusx/sig-infra#170

#### Testing
- checkout branch
- run terraform plan  
- verify changes
- [GitHub Repo Creation README](https://github.com/catenax-ng/product-onboarding/blob/main/vault/README.md)
#### Additional information

``` bash
Terraform will perform the following actions:

  # github_repository.repositories["product-federated-catalogue"] will be created
  + resource "github_repository" "repositories" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + auto_init                   = true
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = true
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_discussions             = false
      + has_downloads               = true
      + has_issues                  = false
      + has_projects                = false
      + has_wiki                    = false
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + is_template                 = false
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "product-federated-catalogue"
      + node_id                     = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + visibility                  = "private"
      + vulnerability_alerts        = true

      + security_and_analysis {
          + advanced_security {
              + status = (known after apply)
            }

          + secret_scanning {
              + status = (known after apply)
            }

          + secret_scanning_push_protection {
              + status = (known after apply)
            }
        }
    }

  # github_team_repository.team-repository-access["product-federated-catalogue-product-essential-services"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "product-federated-catalogue"
      + team_id    = "5788681"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```


[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>