### PR TITLE
chore: enable issues for private sustainability repos

### DIFF
--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -1813,7 +1813,7 @@ github_repositories = {
   "product-agents-edc" : {
     name : "product-agents-edc"
     team_name : "product-knowledge"
-    description : "EDC Agent Plane"
+    description : "EDC Agent Plane Extensions (Deprecated - use tx-knowledge-agents-edc instead) "
     visibility : "public"
     has_issues : false
     has_discussions : false
@@ -1833,7 +1833,7 @@ github_repositories = {
   "product-agents" : {
     name : "product-agents"
     team_name : "product-knowledge"
-    description : "Reference Implementations of Knowledge Agents"
+    description : "Reference Implementations of Knowledge Agents (Deprecated - use tx-knowledge-agents instead)"
     visibility : "public"
     has_issues : false
     has_discussions : false
@@ -1935,7 +1935,7 @@ github_repositories = {
     team_name : "product-architects-sustainability-team"
     description : ""
     visibility : "private"
-    has_issues : false
+    has_issues : true
     has_discussions : false
     homepage_url : ""
     topics : []
@@ -1955,7 +1955,7 @@ github_repositories = {
     team_name : "product-architects-sustainability-team"
     description : ""
     visibility : "private"
-    has_issues : false
+    has_issues : true
     has_discussions : false
     homepage_url : ""
     topics : []


### PR DESCRIPTION
### What would be changed or will be added with this PR?

- enable issue option for requested 2 repositories
- updated description for 2 repositories

#### Why do i want to change this?

fixes eclipse-tractusx/sig-infra#206

### Testing
- checkout branch 
- terraform init (optional)
- terraform plan
- verify changes

### Additional information
``` bash
Terraform will perform the following actions:

  # github_repository.repositories["product-sustainability-kits"] will be updated in-place
  ~ resource "github_repository" "repositories" {
      ~ has_issues                  = false -> true
        id                          = "product-sustainability-kits"
        name                        = "product-sustainability-kits"
        # (31 unchanged attributes hidden)
    }

  # github_repository.repositories["product-sustainability-standardization"] will be updated in-place
  ~ resource "github_repository" "repositories" {
      ~ has_issues                  = false -> true
        id                          = "product-sustainability-standardization"
        name                        = "product-sustainability-standardization"
        # (30 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```


[FaGru3n](https://github.com/FaGru3n), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>