### PR TITLE
feat: new ArgoCD project setup

### DIFF
--- a/argocd/product-behaviour-twin-pilot/base-read-only/kustomization.yaml
+++ b/argocd/product-behaviour-twin-pilot/base-read-only/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
 
   - resources/argo-project.yaml
-  - resources/argo-repo.yaml
+#  - resources/argo-repo.yaml
   - resources/avp-secret.yaml
   - resources/namespace.yaml

--- a/argocd/product-behaviour-twin-pilot/stable/kustomization.yaml
+++ b/argocd/product-behaviour-twin-pilot/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-behaviour-twin-pilot/stable/resources/argo-project.yaml
+++ b/argocd/product-behaviour-twin-pilot/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-behaviour-twin-pilot
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-behaviour-twin-pilot
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-behaviour-twin-pilot.
+      policies:
+        - p, proj:project-behaviour-twin-pilot:team-admin, applications, *, project-behaviour-twin-pilot/*, allow
+        - p, proj:project-behaviour-twin-pilot:team-admin, exec, create, project-behaviour-twin-pilot/*, allow
+      groups:
+        - catenax-ng:product-behaviour-twin-pilot
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-behaviour-twin-pilot:read-only, applications, get, project-behaviour-twin-pilot/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-behaviour-twin-pilot/stable/resources/avp-secret.yaml
+++ b/argocd/product-behaviour-twin-pilot/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/behaviour-twin-pilot"
+  name: vault-secret
+  namespace: product-behaviour-twin-pilot-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-bpdm/stable/kustomization.yaml
+++ b/argocd/product-bpdm/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-bpdm/stable/resources/argo-project.yaml
+++ b/argocd/product-bpdm/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-bpdm
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-bpdm
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-bpdm.
+      policies:
+        - p, proj:project-bpdm:team-admin, applications, *, project-bpdm/*, allow
+        - p, proj:project-bpdm:team-admin, exec, create, project-bpdm/*, allow
+      groups:
+        - catenax-ng:product-bpdm
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-bpdm:read-only, applications, get, project-bpdm/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-bpdm/stable/resources/avp-secret.yaml
+++ b/argocd/product-bpdm/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/bpdm"
+  name: vault-secret
+  namespace: product-bpdm-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-data-format-transformer/stable/kustomization.yaml
+++ b/argocd/product-data-format-transformer/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-data-format-transformer/stable/resources/argo-project.yaml
+++ b/argocd/product-data-format-transformer/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-data-format-transformer
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-data-format-transformer
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-product-data-format-transformer.
+      policies:
+        - p, proj:project-data-format-transformer:team-admin, applications, *, project-data-format-transformer/*, allow
+        - p, proj:project-data-format-transformer:team-admin, exec, create, project-data-format-transformer/*, allow
+      groups:
+        - catenax-ng:product-data-format-transformer
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-data-format-transformer:read-only, applications, get, project-data-format-transformer/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-data-format-transformer/stable/resources/avp-secret.yaml
+++ b/argocd/product-data-format-transformer/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/data-format-transformer"
+  name: vault-secret
+  namespace: product-data-format-transformer-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-dft/stable/kustomization.yaml
+++ b/argocd/product-dft/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-dft/stable/resources/argo-project.yaml
+++ b/argocd/product-dft/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: product-dft
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-dft
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside product-dft.
+      policies:
+        - p, proj:product-dft:team-admin, applications, *, product-dft/*, allow
+        - p, proj:product-dft:team-admin, exec, create, product-dft/*, allow
+      groups:
+        - catenax-ng:product-dft
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:product-dft:read-only, applications, get, product-dft/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-dft/stable/resources/avp-secret.yaml
+++ b/argocd/product-dft/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/dft"
+  name: vault-secret
+  namespace: product-dft-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-edc/stable/kustomization.yaml
+++ b/argocd/product-edc/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-edc/stable/resources/argo-project.yaml
+++ b/argocd/product-edc/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-edc
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-edc
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-edc.
+      policies:
+        - p, proj:project-edc:team-admin, applications, *, project-edc/*, allow
+        - p, proj:project-edc:team-admin, exec, create, product-edc/*, allow
+      groups:
+        - catenax-ng:product-edc
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-edc:read-only, applications, get, project-edc/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-edc/stable/resources/avp-secret.yaml
+++ b/argocd/product-edc/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/edc"
+  name: vault-secret
+  namespace: product-edc-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-essential-services/base-read-only/kustomization.yaml
+++ b/argocd/product-essential-services/base-read-only/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
 
   - resources/argo-project.yaml
-  - resources/argo-repo.yaml
+#  - resources/argo-repo.yaml
   - resources/avp-secret.yaml
   - resources/namespace.yaml

--- a/argocd/product-essential-services/stable/kustomization.yaml
+++ b/argocd/product-essential-services/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-essential-services/stable/resources/argo-project.yaml
+++ b/argocd/product-essential-services/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-essential-services
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-essential-services
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-essential-services.
+      policies:
+        - p, proj:project-essential-services:team-admin, applications, *, project-essential-services/*, allow
+        - p, proj:project-essential-services:team-admin, exec, create, project-essential-services/*, allow
+      groups:
+        - catenax-ng:product-essential-services
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-essential-services:read-only, applications, get, project-essential-services/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-essential-services/stable/resources/avp-secret.yaml
+++ b/argocd/product-essential-services/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/essential-services"
+  name: vault-secret
+  namespace: product-essential-services-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-item-relationship-service-frontend/stable/kustomization.yaml
+++ b/argocd/product-item-relationship-service-frontend/stable/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml
+#  - resources/argocd-notifications-cm.yaml
+#  - resources/argocd-notifications-secret.yaml

--- a/argocd/product-item-relationship-service-frontend/stable/resources/argo-project.yaml
+++ b/argocd/product-item-relationship-service-frontend/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-item-relationship-service-frontend
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-item-relationship-service-frontend
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-item-relationship-service-frontend.
+      policies:
+        - p, proj:project-item-relationship-service-frontend:team-admin, applications, *, project-item-relationship-service-frontend/*, allow
+        - p, proj:project-item-relationship-service-frontend:team-admin, exec, create, project-item-relationship-service-frontend/*, allow
+      groups:
+        - catenax-ng:product-item-relationship-service-frontend
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-item-relationship-service-frontend:read-only, applications, get, project-item-relationship-service-frontend/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-item-relationship-service-frontend/stable/resources/avp-secret.yaml
+++ b/argocd/product-item-relationship-service-frontend/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/item-relationship-service-frontend"
+  name: vault-secret
+  namespace: product-item-relationship-service-frontend-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-managed-identity-wallets/stable/kustomization.yaml
+++ b/argocd/product-managed-identity-wallets/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-managed-identity-wallets/stable/resources/argo-project.yaml
+++ b/argocd/product-managed-identity-wallets/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-managed-identity-wallets
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-managed-identity-wallets
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-managed-identity-wallets.
+      policies:
+        - p, proj:project-managed-identity-wallets:team-admin, applications, *, project-managed-identity-wallets/*, allow
+        - p, proj:project-managed-identity-wallets:team-admin, exec, create, project-managed-identity-wallets/*, allow
+      groups:
+        - catenax-ng:product-managed-identity-wallets
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-managed-identity-wallets:read-only, applications, get, project-managed-identity-wallets/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-managed-identity-wallets/stable/resources/avp-secret.yaml
+++ b/argocd/product-managed-identity-wallets/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/managed-identity-wallets"
+  name: vault-secret
+  namespace: product-managed-identity-wallets-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-material-pass/stable/kustomization.yaml
+++ b/argocd/product-material-pass/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-material-pass/stable/resources/argo-project.yaml
+++ b/argocd/product-material-pass/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-material-pass
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-material-pass
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-material-pass.
+      policies:
+        - p, proj:project-material-pass:team-admin, applications, *, project-material-pass/*, allow
+        - p, proj:project-material-pass:team-admin, exec, create, project-material-pass/*, allow
+      groups:
+        - catenax-ng:product-material-pass
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-material-pass:read-only, applications, get, project-material-pass/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-material-pass/stable/resources/avp-secret.yaml
+++ b/argocd/product-material-pass/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/material-pass"
+  name: vault-secret
+  namespace: product-material-pass-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-portal/stable/kustomization.yaml
+++ b/argocd/product-portal/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-portal/stable/resources/argo-project.yaml
+++ b/argocd/product-portal/stable/resources/argo-project.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-portal
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-portal
+      server: https://kubernetes.default.svc
+    - namespace: product-iam
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-portal.
+      policies:
+        - p, proj:project-portal:team-admin, applications, *, project-portal/*, allow
+        - p, proj:project-portal:team-admin, exec, create, project-portal/*, allow
+      groups:
+        - catenax-ng:product-portal
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-portal:read-only, applications, get, project-portal/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-portal/stable/resources/avp-secret.yaml
+++ b/argocd/product-portal/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/portal"
+  name: vault-secret
+  namespace: product-portal-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-semantics/base-read-only/kustomization.yaml
+++ b/argocd/product-semantics/base-read-only/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
 
   - resources/argo-project.yaml
-  - resources/argo-repo.yaml
+#  - resources/argo-repo.yaml
   - resources/avp-secret.yaml
   - resources/namespace.yaml

--- a/argocd/product-semantics/stable/kustomization.yaml
+++ b/argocd/product-semantics/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-semantics/stable/resources/argo-project.yaml
+++ b/argocd/product-semantics/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-semantics
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-semantics
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-semantics.
+      policies:
+        - p, proj:project-semantics:team-admin, applications, *, project-semantics/*, allow
+        - p, proj:project-semantics:team-admin, exec, create, project-semantics/*, allow
+      groups:
+        - catenax-ng:product-semantics
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-semantics:read-only, applications, get, project-semantics/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-semantics/stable/resources/avp-secret.yaml
+++ b/argocd/product-semantics/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/semantics"
+  name: vault-secret
+  namespace: product-semantics-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-traceability-foss/stable/kustomization.yaml
+++ b/argocd/product-traceability-foss/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-traceability-foss/stable/resources/argo-project.yaml
+++ b/argocd/product-traceability-foss/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-traceability-foss
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-traceability-foss
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-traceability-foss.
+      policies:
+        - p, proj:project-traceability-foss:team-admin, applications, *, project-traceability-foss/*, allow
+        - p, proj:project-traceability-foss:team-admin, exec, create, project-traceability-foss/*, allow
+      groups:
+        - catenax-ng:product-traceability-foss
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-traceability-foss:read-only, applications, get, project-traceability-foss/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-traceability-foss/stable/resources/avp-secret.yaml
+++ b/argocd/product-traceability-foss/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/traceability-foss"
+  name: vault-secret
+  namespace: product-traceability-foss-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/argocd/product-value-added-service/stable/kustomization.yaml
+++ b/argocd/product-value-added-service/stable/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base-read-only
+  - resources/avp-secret.yaml
+
+patchesStrategicMerge:
+  - resources/argo-project.yaml

--- a/argocd/product-value-added-service/stable/resources/argo-project.yaml
+++ b/argocd/product-value-added-service/stable/resources/argo-project.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-value-added-service
+  namespace: argocd
+spec:
+  sourceRepos:
+    - https://eclipse-tractusx.github.io/charts/dev
+  destinations:
+    - namespace: product-value-added-service
+      server: https://kubernetes.default.svc
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-value-added-service.
+      policies:
+        - p, proj:project-value-added-service:team-admin, applications, *, project-value-added-service/*, allow
+        - p, proj:project-value-added-service:team-admin, exec, create, project-value-added-service/*, allow
+      groups:
+        - catenax-ng:product-value-added-service
+    - name: read-only
+      description: Read only access to the project
+      policies:
+        - p, proj:project-value-added-service:read-only, applications, get, project-value-added-service/*, allow
+      groups:
+        - catenax-ng:release-management
+        - catenax-ng:test-management

--- a/argocd/product-value-added-service/stable/resources/avp-secret.yaml
+++ b/argocd/product-value-added-service/stable/resources/avp-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/value-added-service"
+  name: vault-secret
+  namespace: product-value-added-service-pen
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/cluster/stable/helm-repo/eclipse-tractusx-helm-repo.yaml
+++ b/cluster/stable/helm-repo/eclipse-tractusx-helm-repo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eclipse-tractusx
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: 'Eclipse-TractusX Helm Repositoriy'
+  url: 'https://eclipse-tractusx.github.io/charts/dev'
+  type: 'helm'

--- a/cluster/stable/kustomization.yaml
+++ b/cluster/stable/kustomization.yaml
@@ -19,4 +19,4 @@ resources:
 
   - helm-repo/eclipse-tractusx-helm-repo.yaml
   - storage-class/standard-ssd-lrs-retain.yaml
-  - pull-secret/secret.yaml
+#  - pull-secret/secret.yaml

--- a/cluster/stable/kustomization.yaml
+++ b/cluster/stable/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - ../../argocd/product-traceability-foss/read-write
   - ../../argocd/product-value-added-service/read-write
 
+  - helm-repo/eclipse-tractusx-helm-repo.yaml
   - storage-class/standard-ssd-lrs-retain.yaml
   - pull-secret/secret.yaml

--- a/cluster/stable/kustomization.yaml
+++ b/cluster/stable/kustomization.yaml
@@ -3,19 +3,19 @@ kind: Kustomization
 
 resources:
   # Product Onboarding
-  - ../../argocd/product-behaviour-twin-pilot/read-write
-  - ../../argocd/product-bpdm/read-write
-  - ../../argocd/product-data-format-transformer/read-write
-  - ../../argocd/product-dft/read-write
-  - ../../argocd/product-edc/read-write
-  - ../../argocd/product-essential-services/read-write
-  - ../../argocd/product-item-relationship-service-frontend/read-write
-  - ../../argocd/product-managed-identity-wallets/read-write
-  - ../../argocd/product-material-pass/read-write
-  - ../../argocd/product-portal/read-write
-  - ../../argocd/product-semantics/read-write
-  - ../../argocd/product-traceability-foss/read-write
-  - ../../argocd/product-value-added-service/read-write
+  - ../../argocd/product-behaviour-twin-pilot/stable
+  - ../../argocd/product-bpdm/stable
+  - ../../argocd/product-data-format-transformer/stable
+  - ../../argocd/product-dft/stable
+  - ../../argocd/product-edc/stable
+  - ../../argocd/product-essential-services/stable
+  - ../../argocd/product-item-relationship-service-frontend/stable
+  - ../../argocd/product-managed-identity-wallets/stable
+  - ../../argocd/product-material-pass/stable
+  - ../../argocd/product-portal/stable
+  - ../../argocd/product-semantics/stable
+  - ../../argocd/product-traceability-foss/stable
+  - ../../argocd/product-value-added-service/stable
 
   - helm-repo/eclipse-tractusx-helm-repo.yaml
   - storage-class/standard-ssd-lrs-retain.yaml


### PR DESCRIPTION
New ArgoCD project setup for STABLE env:
- add Eclipse-TractusX Helm repo as a general available repo (dicretly selectable via drop down menue)
- limit ArgoCD projects `sourceRepo` to Eclipse-TractusX Helm repo
- remove penetration (`product-name-pen`) ns from ArgoCD projects
- remove imagePullSecret to prohibit usage of private docker images from `ghcr.io/cantenax-ng`

After PR has been merged, delete the following resources manually if necessary:
- `argocd/secrets/idses-frontend-apps-repo`
- `argocd/secrets/product-behaviour-twin-minio`
- `argocd/secrets/product-behaviour-twin-pilot-private`
- `argocd/secrets/product-semantics-repo`
- `default/secrets/machineuser-pull-secret-ro`
- `namespaces/product-*-pen`