### PR TITLE
feat: add kyverno policies

### DIFF
--- a/cluster/devsecops-testing/kustomization.yaml
+++ b/cluster/devsecops-testing/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   # Product Onboarding
   - ../../argocd/product-example/read-write
   - ../../argocd/product-portal/read-write
+  - ../../kyverno/

--- a/kyverno/require-non-root-groups.yaml
+++ b/kyverno/require-non-root-groups.yaml
@@ -1,0 +1,86 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-non-root-groups
+  annotations:
+    policies.kyverno.io/title: Require Non-Root Groups
+    policies.kyverno.io/category: Sample, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.6
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Containers should be forbidden from running with a root primary or supplementary GID.
+      This policy ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
+      greater than zero (i.e., non root). A known issue prevents a policy such as this
+      using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: check-runasgroup
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Running with root group IDs is disallowed. The fields
+          spec.securityContext.runAsGroup, spec.containers[*].securityContext.runAsGroup,
+          spec.initContainers[*].securityContext.runAsGroup, and
+          spec.ephemeralContainers[*].securityContext.runAsGroup must be
+          set to a value greater than zero.
+        anyPattern:
+        - spec:
+            securityContext:
+              runAsGroup: ">0"
+            =(ephemeralContainers):
+              - =(securityContext):
+                  =(runAsGroup): ">0"
+            =(initContainers):
+              - =(securityContext):
+                  =(runAsGroup): ">0"
+            containers:
+              - =(securityContext):
+                  =(runAsGroup): ">0"
+        - spec:
+            =(ephemeralContainers):
+              - securityContext:
+                  runAsGroup: ">0"
+            =(initContainers):
+              - securityContext:
+                  runAsGroup: ">0"
+            containers:
+              - securityContext:
+                  runAsGroup: ">0"
+    - name: check-supplementalgroups
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Containers cannot run with a root primary or supplementary GID. The field
+          spec.securityContext.supplementalGroups must be unset or
+          set to a value greater than zero.
+        pattern:
+          spec:
+            =(securityContext):
+              =(supplementalGroups): ">0"
+    - name: check-fsgroup
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Containers cannot run with a root primary or supplementary GID. The field
+          spec.securityContext.fsGroup must be unset or set to a value greater than zero.
+        pattern:
+          spec:
+            =(securityContext):
+              =(fsGroup): ">0"

--- a/kyverno/require-run-as-non-root-user.yaml
+++ b/kyverno/require-run-as-non-root-user.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-run-as-non-root-user
+  annotations:
+    policies.kyverno.io/title: Require Run As Non-Root User
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root users. This policy ensures
+      `runAsUser` is either unset or set to a number greater than zero.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: run-as-non-root-user
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Running as root is not allowed. The fields spec.securityContext.runAsUser,
+          spec.containers[*].securityContext.runAsUser, spec.initContainers[*].securityContext.runAsUser,
+          and spec.ephemeralContainers[*].securityContext.runAsUser must be unset or
+          set to a number greater than zero.
+        pattern:
+          spec:
+            =(securityContext):
+              =(runAsUser): ">0"
+            =(ephemeralContainers):
+            - =(securityContext):
+                =(runAsUser): ">0"
+            =(initContainers):
+            - =(securityContext):
+                =(runAsUser): ">0"
+            containers:
+            - =(securityContext):
+                =(runAsUser): ">0"


### PR DESCRIPTION
PR to add  security context kyverno policies (non root group and user validation) to devsecops cluster automation.

Updates: https://github.com/eclipse-tractusx/sig-infra/issues/111