### PR TITLE
feat: enable non-root user kyverno policies for clusters

### DIFF
--- a/cluster/beta/kustomization.yaml
+++ b/cluster/beta/kustomization.yaml
@@ -15,3 +15,6 @@ resources:
 
   - storage-class/standard-ssd-lrs-retain.yaml
   - pull-secret/secret.yaml
+
+# Kyverno policies (Audit mode)
+  - ../../kyverno/policies-audit

--- a/cluster/dev/kustomization.yaml
+++ b/cluster/dev/kustomization.yaml
@@ -34,5 +34,8 @@ resources:
   - storage-class/standard-ssd-lrs-retain.yaml
   - pull-secret/secret.yaml
 
+# Kyverno policies (Audit mode)
+  - ../../kyverno/policies-audit
+
 patchesStrategicMerge:
   - argocd-resource-patches/project-traceability-irs.yaml

--- a/cluster/devsecops-testing/kustomization.yaml
+++ b/cluster/devsecops-testing/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   # Product Onboarding
   - ../../argocd/product-example/read-write
   - ../../argocd/product-portal/read-write
+
+# Kyverno policies (Audit mode)
   - ../../kyverno/policies-audit

--- a/cluster/int/kustomization.yaml
+++ b/cluster/int/kustomization.yaml
@@ -33,6 +33,9 @@ resources:
   - storage-class/standard-ssd-lrs-retain.yaml
   - pull-secret/secret.yaml
 
+# Kyverno policies (Audit mode)
+  - ../../kyverno/policies-audit
+
 #patchesStrategicMerge:
 #  - argocd-resource-patches/project-traceability-irs.yaml
 #  - argocd-resource-patches/argo-notifications-cm.yaml

--- a/cluster/pre-prod/kustomization.yaml
+++ b/cluster/pre-prod/kustomization.yaml
@@ -28,3 +28,6 @@ resources:
 
   - storage-class/standard-ssd-lrs-retain.yaml
   - pull-secret/secret.yaml
+
+# Kyverno policies (Audit mode)
+  - ../../kyverno/policies-audit

--- a/cluster/stable/kustomization.yaml
+++ b/cluster/stable/kustomization.yaml
@@ -21,3 +21,6 @@ resources:
   - helm-repo/eclipse-tractusx-helm-repo.yaml
   - storage-class/standard-ssd-lrs-retain.yaml
 #  - pull-secret/secret.yaml
+
+# Kyverno policies (Audit mode)
+  - ../../kyverno/policies-audit

--- a/kyverno/policies-audit/kustomization.yaml
+++ b/kyverno/policies-audit/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - require-non-root-groups.yaml
   - require-run-as-non-root-user.yaml 


### PR DESCRIPTION
PR to enable non-root user kyverno policy in audit mode on all clusters. It also disables currently not required non-root group policy on devsecops cluster.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/111