### PR TITLE
chore: add kyverno policy container image tag

### DIFF
--- a/kyverno/policies-audit/disallow-latest-image.yaml
+++ b/kyverno/policies-audit/disallow-latest-image.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-latest-tag
+  annotations:
+    policies.kyverno.io/title: Disallow Latest Tag
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The ':latest' tag is mutable and can lead to unexpected errors if the
+      image changes. A best practice is to use an immutable tag that maps to
+      a specific version of an application Pod. This policy validates that the image
+      specifies a tag and that it is not called `latest`.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: require-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "An image tag is required."
+        pattern:
+          spec:
+            containers:
+              - image: "*:*"
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: "Using a mutable image tag e.g. 'latest' is not allowed. → TRG 5.05"
+        pattern:
+          spec:
+            containers:
+              - image: "!*:latest"

--- a/kyverno/policies-audit/kustomization.yaml
+++ b/kyverno/policies-audit/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - require-run-as-non-root-user.yaml 
+  - require-run-as-non-root-user.yaml
+  - disallow-latest-image.yaml


### PR DESCRIPTION
This policy checks, if
- a valid image tag is given
- the image tag is not `latest`

Policy is taken over from Kyverno Policy example:
https://kyverno.io/policies/best-practices/disallow-latest-tag/disallow-latest-tag/

This is the implementation of issue:
- eclipse-tractusx/sig-infra#107