### PR TITLE
chore: create new repo product-behaviour-twin-demo + adapt changes gh-team, source branch for gh-pages

### DIFF
--- a/github/.terraform.lock.hcl
+++ b/github/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.93.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:SKhtBNyVOKexC8XTioruXEQYHFBF1n8yiP8LfRMl96M=",
     "h1:lUioDFuE2xonpcH5QP55F1WZu7oAOGbhXbSaQSBGIR8=",
     "zh:0fc3169c32e43e44a34308856ebf4209c8c13e2526993bb4d9dc81fedc91f60a",
     "zh:10ed7bc146480d4261c5a899032947c3908fa3661efe797128fb961c0a0a4eb6",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "~> 6.0"
   hashes = [
     "h1:YGUmIpK8zBYXssW5vJcQEaRvimE/kxcIifcEDnfThMQ=",
+    "h1:jLOsi4Qu5g5D2/n/xg/CljAKCRH9F9paiWRZtyzWR+k=",
     "zh:0d12fde69c54d358af3a45cf1610b711e1cd6a5d0be8d71c24729f28faa4a67d",
     "zh:501fd9a181bbb1f3e70c3a54463bc16974569dddd1311fdd682c3b893ebc8455",
     "zh:69a486e2b2db2f7ff947027e5e245b48a1f71e10955e7243419c15d9d8330d54",

--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -198,7 +198,7 @@ github_teams = {
   },
   "product-cgi-dcm-foss" : {
     name : "product-dcm"
-    description : "Content team for tx-dcm-backend"
+    description : "Content team for tx-demand-capacity-mgmt"
   },
   "product-quality-foss-app-team" : {
     name : "product-quality-foss-app-team"
@@ -1371,7 +1371,7 @@ github_repositories = {
     topics : []
     pages : {
       enabled : true
-      branch : "main"
+      branch : "gh-pages"
       build_type: "legacy"
     }
     is_template : false
@@ -2056,6 +2056,27 @@ github_repositories = {
     codeowners : null
     archived : false
   }
+  "product-behaviour-twin-demo" : {
+    name : "product-behaviour-twin-demo"
+    team_name : "product-behaviour-twin-pilot"
+    description : ""
+    visibility : "public"
+    has_issues : false
+    has_discussions : false
+    homepage_url : ""
+    topics : []
+    pages : {
+      enabled : false
+      branch : "gh-pages"
+      build_type: "legacy"
+    }
+    is_template : false
+    uses_template : false
+    template : null
+    codeowners_available : false
+    codeowners : null
+    archived : false
+  }
 }
 
 github_repositories_teams = {
@@ -2524,5 +2545,10 @@ github_repositories_teams = {
     team_name : "product-architects-sustainability-team"
     repository : "product-sustainability-standardization"
     permission : "maintain"
-  }
+  },
+  "product-behaviour-twin-demo-product-behaviour-twin-pilot" : {
+    team_name : "product-behaviour-twin-pilot"
+    repository : "product-behaviour-twin-demo"
+    permission : "maintain"
+  },
 }

--- a/github/terraform.tfvars
+++ b/github/terraform.tfvars
@@ -2055,7 +2055,7 @@ github_repositories = {
     codeowners_available : false
     codeowners : null
     archived : false
-  }
+  },
   "product-behaviour-twin-demo" : {
     name : "product-behaviour-twin-demo"
     team_name : "product-behaviour-twin-pilot"
@@ -2550,5 +2550,5 @@ github_repositories_teams = {
     team_name : "product-behaviour-twin-pilot"
     repository : "product-behaviour-twin-demo"
     permission : "maintain"
-  },
+  }
 }


### PR DESCRIPTION
#### What would be changed or will be added with this PR?
- add a new repo _product-behaviour-twin-demo_
- add a new team permission to [product-behaviour-twin-pilot](https://github.com/orgs/catenax-ng/teams/product-behaviour-twin-pilot) to this new repo _product-behaviour-twin-demo_

#### Why do i want to change this?
- demo purpose written [here](https://github.com/eclipse-tractusx/sig-infra/issues/478#issuecomment-2079176307)

updates https://github.com/eclipse-tractusx/sig-infra/issues/478

#### Testing
- checkout feature branch
- terraform init (optional)
- terraform plan 
- verify changes

#### Additional information

```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # github_repository.repositories["product-behaviour-twin-demo"] will be created
  + resource "github_repository" "repositories" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + auto_init                   = true
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = true
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_discussions             = false
      + has_downloads               = true
      + has_issues                  = false
      + has_projects                = false
      + has_wiki                    = false
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + is_template                 = false
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "product-behaviour-twin-demo"
      + node_id                     = (known after apply)
      + primary_language            = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + topics                      = (known after apply)
      + visibility                  = "public"
      + vulnerability_alerts        = true
      + web_commit_signoff_required = false

      + security_and_analysis {
          + advanced_security {
              + status = (known after apply)
            }

          + secret_scanning {
              + status = (known after apply)
            }

          + secret_scanning_push_protection {
              + status = (known after apply)
            }
        }
    }

  # github_team_repository.team-repository-access["product-behaviour-twin-demo-product-behaviour-twin-pilot"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "product-behaviour-twin-demo"
      + team_id    = "6177751"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
