### PR TITLE
feat: add ro vault token for portal bdrs

### DIFF
--- a/vault/.terraform.lock.hcl
+++ b/vault/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "~> 3.0"
   hashes = [
     "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
+    "h1:vfd+Muv9666zrRtC1E0JzBt3KTgwiu8Z1hOvsKFXhs0=",
     "h1:ygpAv2ggEm3aMJTPvlvVaPdegoxriKpDSXSbIO9qqB4=",
     "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
     "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/vault" {
   constraints = "~> 3.0"
   hashes = [
     "h1:7xTn3wS4mMa3HpqqnhtBEs9EModIY9mkDrCVSUP2ADM=",
+    "h1:9/jzUXOqndgysNSiOMVy8NGPimQ1ZATZVkpLGk8NNCM=",
     "h1:v/3HHQpH6Qz5UZ82stshfLbcL3fwSy0OAnL54zQqa5A=",
     "zh:06eca14b5c002aa9f93ac2fe05da3e3d320d7804a896021a7a8ba3f78df2b1b7",
     "zh:104594e517adad642e73a32e11d3cbf64264d645d5ebbb4a30e503bd53d133c5",

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -220,3 +220,34 @@ resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
   role_name      = each.value.github_team
   bound_claims   = { "groups" : "catenax-ng:${each.value.github_team}" }
 }
+
+resource "vault_policy" "bdrs-vault-policy" {
+  name   = "portal-bdrs-ro"
+  policy = <<EOT
+path "portal/*" {
+  capabilities = [ "read" ]
+}
+EOT
+}
+
+resource "vault_token" "portal-bdrs-token" {
+  display_name = "portal-bdrs-vault-token"
+
+  policies = [ "portal-bdrs-ro" ]
+
+  renewable = true
+  ttl = "30d"
+
+  metadata = {
+    "purpose" = "bdrs vault access"
+  }
+}
+
+resource "vault_generic_secret" "portal-vault-token-secret" {
+  path      = "portal/bdrs-vault"
+  data_json = <<EOT
+{
+  "token":   "${vault_token.portal-bdrs-token.client_token}"
+}
+EOT
+}

--- a/vault/main.tf
+++ b/vault/main.tf
@@ -236,7 +236,7 @@ resource "vault_token" "portal-bdrs-token" {
   policies = [ "portal-bdrs-ro" ]
 
   renewable = true
-  ttl = "30d"
+  ttl = "768h"
 
   metadata = {
     "purpose" = "bdrs vault access"


### PR DESCRIPTION
This PR introduces new terraform resources for the consortia vault setup.
Applying the new resources will create a `token` for authentication, that is assigned the portal read-only `policy`.
The generated token value is placed in the portal `secret engine`

Fixes eclipse-tractusx/sig-infra#500